### PR TITLE
add node path configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Reasons why this might work for you
 - Allows a single overview of all tasks available to you
 - Gulpfile.[coffee|js] is automatically located, either withing the root project folder or a sub-folder
 
+## Configuration
+
+Because Gulp requires the node executable, there is a potential for it to break if you use [nvm](https://github.com/creationix/nvm) or [nodebrew](https://github.com/hokaccha/nodebrew). If it doesn't initally work, you can specify node's bin folder in the package settings.
+
+*NOTE: if you type* `which node` *into the console you can get node's system path, but you need to remove "node" from the end of it for it to work.*
+
 ## Where
 
 The Atom package can be found on the Atom registry, [https://atom.io/packages/gulp-control](https://atom.io/packages/gulp-control).

--- a/lib/gulp-control-view.coffee
+++ b/lib/gulp-control-view.coffee
@@ -118,7 +118,7 @@ class GulpControlView extends View
 
     process.env.PATH = switch process.platform
       when 'win32' then process.env.PATH
-      else "#{process.env.PATH}:/usr/local/bin"
+      else "#{process.env.PATH}:" + atom.config.get('gulp-control.nodePath')
 
     options =
       cwd: @gulpCwd

--- a/lib/gulp-control.coffee
+++ b/lib/gulp-control.coffee
@@ -26,3 +26,10 @@ module.exports = GulpControl =
     return
 
   serialize: ->
+
+  config:
+    nodePath:
+      title: 'Bin Path',
+      description: 'This should be set to the folder in which the node executable is located. This can be found by typing \'which node\' from the command line, but you need to remove \'node\' from the end.'
+      type: 'string'
+      default: '/usr/local/bin'


### PR DESCRIPTION
closes #19
- adds nodePath config var to package

@jacogr this should be a simple fix for users who use such things as nvm or nodebrew