### PR TITLE
Handle output from in-place line updates

### DIFF
--- a/lib/gulp-control-view.coffee
+++ b/lib/gulp-control-view.coffee
@@ -148,6 +148,8 @@ class GulpControlView extends View
     return
 
   writeOutput: (line, klass) ->
+    parts = line.split('\r')
+    line = parts[parts.length-1]
     if line and line.length
       @outputPane.append "<pre class='#{klass or ''}'>#{line}</pre>"
       @outputPane.scrollToBottom()


### PR DESCRIPTION
This (hacky) patch is to handle output from gulp where lines overwrite themselves, ie to provide a "live display". An example of such is when using the mocha-yar reporter which provides a running count of completed tests without scrolling: when using on a console, all is good and well. When using from within atom-gulp-control, the package receives lines buffered by newline so all of the incremental line updates come as one blob with the carriage returns in place. This patch simply looks for carriage returns and takes the last line.
Technically, it's not the most correct patch: properly, we should create a buffer and overwrite it with each successive line to get the final output; however for the most immediate purpose, it suffices.