### PR TITLE
Issue #45: Tiny fix for pane selection

### DIFF
--- a/lib/gulp-control.coffee
+++ b/lib/gulp-control.coffee
@@ -21,7 +21,7 @@ module.exports = GulpControl =
     views.push view
 
     pane = atom.workspace.getActivePane()
-    item = pane.addItem view, 0
+    item = pane.addItem view, {index: 0}
     pane.activateItem item
     return
 


### PR DESCRIPTION
Very simple fix for the deprecation warning from `atom`'s built-in deprecation thing.