### PR TITLE
fix for deprecation error

### DIFF
--- a/lib/gulp-control.coffee
+++ b/lib/gulp-control.coffee
@@ -21,7 +21,7 @@ module.exports = GulpControl =
     views.push view
 
     pane = atom.workspace.getActivePane()
-    item = pane.addItem view, 0
+    item = pane.addItem view, {index:0}
     pane.activateItem item
     return
 


### PR DESCRIPTION
pane.addItem view, 0 was deprecated code, small refactoring to work with latest API and avoid deprecation warning in Atom editor bottom panel. 